### PR TITLE
clamping to avoid Infinity bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,5 +147,14 @@ function getValue(start, end, fromTime, toTime, at){
   var time = toTime - fromTime
   var truncateTime = at - fromTime
   var phase = truncateTime / time
-  return start + phase * difference
+  var value = start + phase * difference
+
+  if (value <= start) {
+      value = start
+  }
+  if (value >= end) {
+      value = end
+  }
+
+  return value
 }


### PR DESCRIPTION
Hi,
I came across your repository when trying to fix a problem I had when I had a long (2 second) ramp on the attack, and the release kicked in before the ramp was complete. In my own code, this wasn't working properly until I implemented a similar solution to yours of the method `getValue` thanks for that!

However, there are some cases where sometimes the value you are returning returns as `Infinity`.
and the way you implemented it on your code, it will trigger an error on the `linearRampToValueAtTime` method, returning something like:
`Uncaught TypeError: Failed to execute 'linearRampToValueAtTime' on 'AudioParam': The provided float value is non-finite.`

So, what I did here was to clamp to the lowest value, and also to the highest value.

Works like a charm. Hope its useful to you too.

Cheers
Andre
